### PR TITLE
Add offline mode with bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ npm start
 ```
 
 2. Open [http://localhost:3000](http://localhost:3000) in your browser. Use the simple interface to create or join a room and try the basic round flow.
+
+### Offline mode
+
+Run the server with local bots for a quick single-player or hotseat session:
+
+```bash
+npm run offline
+```
+
+Use `BOT_COUNT` to control how many bots join automatically (default is `3`).

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,9 @@ app.use(express.static(path.resolve(__dirname, '../client')));
 
 const rooms = {};
 
+const OFFLINE = process.env.OFFLINE === '1' || process.env.OFFLINE === 'true';
+const BOT_COUNT = parseInt(process.env.BOT_COUNT || '3', 10);
+
 function createRoomId() {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   let id;
@@ -34,6 +37,27 @@ function getState(roomId) {
   };
 }
 
+function spawnBots(roomId) {
+  const room = rooms[roomId];
+  if (!room) return;
+  for (let i = 1; i <= BOT_COUNT; i++) {
+    const id = `bot${i}`;
+    room.players[id] = { id, name: `Bot ${i}`, bot: true };
+  }
+}
+
+function runBots(roomId) {
+  if (!OFFLINE) return;
+  const room = rooms[roomId];
+  if (!room) return;
+  const bots = Object.values(room.players).filter(p => p.bot);
+  bots.forEach((bot, idx) => {
+    setTimeout(() => {
+      io.to(roomId).emit('cardPlayed', { playerId: bot.id, cardIndex: Math.floor(Math.random() * 3) });
+    }, 500 * (idx + 1));
+  });
+}
+
 io.on('connection', (socket) => {
   socket.on('createRoom', (callback) => {
     const roomId = createRoomId();
@@ -46,7 +70,13 @@ io.on('connection', (socket) => {
     };
     socket.join(roomId);
     rooms[roomId].players[socket.id] = { id: socket.id, name: 'Captain' };
+    if (OFFLINE) {
+      spawnBots(roomId);
+    }
     callback({ roomId });
+    if (OFFLINE) {
+      io.to(roomId).emit('stateUpdate', getState(roomId));
+    }
   });
 
   socket.on('joinRoom', ({ roomId, name }, callback) => {
@@ -63,6 +93,7 @@ io.on('connection', (socket) => {
     if (!room) return;
     room.gameStarted = true;
     io.to(roomId).emit('gameStarted', getState(roomId));
+    if (OFFLINE) runBots(roomId);
   });
 
   socket.on('playCard', ({ roomId, cardIndex }) => {
@@ -102,6 +133,7 @@ io.on('connection', (socket) => {
     if (!room) return;
     room.round += 1;
     io.to(roomId).emit('newRound', { event: 'event', state: getState(roomId) });
+    if (OFFLINE) runBots(roomId);
   });
 
   socket.on('chatPublic', ({ roomId, text }) => {

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "offline": "OFFLINE=1 node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- implement simple offline mode for server
- spawn bot players in offline mode
- run bots automatically each round
- add `npm run offline` script
- document offline mode usage

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm start` then killed
- `npm run offline` then killed

------
https://chatgpt.com/codex/tasks/task_e_685fc55b9de883329620e328a10f428e