### PR TITLE
Fix room cleanup on player disconnect and test

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -149,7 +149,11 @@ io.on('connection', (socket) => {
     for (const [roomId, room] of Object.entries(rooms)) {
       if (room.players[socket.id]) {
         delete room.players[socket.id];
-        io.to(roomId).emit('stateUpdate', getState(roomId));
+        if (Object.keys(room.players).length === 0) {
+          delete rooms[roomId];
+        } else {
+          io.to(roomId).emit('stateUpdate', getState(roomId));
+        }
       }
     }
   });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -75,6 +75,24 @@ describe('Server basic flow', function () {
       });
     });
   });
+
+  it('removes a room when all players disconnect', (done) => {
+    socket.emit('createRoom', ({ roomId }) => {
+      const socket2 = io(`http://localhost:${SERVER_PORT}`);
+      socket2.emit('joinRoom', { roomId, name: 'Bob' }, () => {
+        socket.close();
+        socket2.close();
+        setTimeout(() => {
+          const socket3 = io(`http://localhost:${SERVER_PORT}`);
+          socket = socket3;
+          socket3.emit('joinRoom', { roomId, name: 'Carol' }, ({ success }) => {
+            expect(success).to.equal(false);
+            done();
+          });
+        }, 50);
+      });
+    });
+  });
 });
 
 describe('Offline mode', function () {


### PR DESCRIPTION
## Summary
- remove empty rooms when players disconnect
- verify empty room cleanup via unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd0c67a34833289423450c5d70576