### PR TITLE
Add abilityUsed client listener and test broadcast

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -73,3 +73,7 @@ socket.on('cardPlayed', ({ playerId, cardIndex }) => {
 socket.on('newRound', ({ event, state }) => {
   addMsg('New round ' + state.round);
 });
+
+socket.on('abilityUsed', ({ playerId }) => {
+  addMsg(playerId + ' used their ability');
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -93,6 +93,21 @@ describe('Server basic flow', function () {
       });
     });
   });
+
+  it('broadcasts ability usage', (done) => {
+    socket.emit('createRoom', ({ roomId }) => {
+      const socket2 = io(`http://localhost:${SERVER_PORT}`);
+      socket2.emit('joinRoom', { roomId, name: 'Alice' }, () => {
+        socket2.on('abilityUsed', ({ playerId, state }) => {
+          expect(playerId).to.be.a('string');
+          expect(state.roomId).to.equal(roomId);
+          socket2.close();
+          done();
+        });
+        socket.emit('useAbility', { roomId });
+      });
+    });
+  });
 });
 
 describe('Offline mode', function () {


### PR DESCRIPTION
## Summary
- display a message when a player uses an ability
- test `abilityUsed` broadcast from the server

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_685fd2681b24833293076933c7a547c1