### PR TITLE
Fix coup captain assignment

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -112,6 +112,7 @@ io.on('connection', (socket) => {
     const room = rooms[roomId];
     if (!room) return;
     room.votes = {};
+    room.coupInitiator = socket.id;
     io.to(roomId).emit('voteStarted', { initiator: anonymous ? null : socket.id });
   });
 
@@ -123,7 +124,10 @@ io.on('connection', (socket) => {
     if (Object.keys(room.votes).length >= total) {
       const yes = Object.values(room.votes).filter(v => v).length;
       const result = yes > total / 2;
-      if (result) room.captain = socket.id;
+      if (result) {
+        room.captain = room.coupInitiator;
+      }
+      delete room.coupInitiator;
       io.to(roomId).emit('coupResult', { result, captain: room.captain });
     }
   });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -108,6 +108,23 @@ describe('Server basic flow', function () {
       });
     });
   });
+
+  it('changes captain to coup initiator when vote passes', (done) => {
+    socket.emit('createRoom', ({ roomId }) => {
+      const socket2 = io(`http://localhost:${SERVER_PORT}`);
+      socket.on('coupResult', ({ result, captain }) => {
+        expect(result).to.equal(true);
+        expect(captain).to.equal(socket.id);
+        socket2.close();
+        done();
+      });
+      socket2.emit('joinRoom', { roomId, name: 'Bob' }, () => {
+        socket.emit('proposeCoup', { roomId, anonymous: false });
+        socket.emit('voteCoup', { roomId, vote: true });
+        socket2.emit('voteCoup', { roomId, vote: true });
+      });
+    });
+  });
 });
 
 describe('Offline mode', function () {


### PR DESCRIPTION
## Summary
- store vote initiator server-side and use it when coup succeeds
- test that the coup changes captain to the initiator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd525f85883329901cba0922fb039