### PR TITLE
Implement basic game state logic

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -31,9 +31,14 @@ function getState(roomId) {
   if (!room) return null;
   return {
     roomId,
-    players: Object.values(room.players).map(p => ({ id: p.id, name: p.name })),
+    players: Object.values(room.players).map(p => ({
+      id: p.id,
+      name: p.name,
+      role: p.role,
+    })),
     captain: room.captain,
     round: room.round,
+    game: room.game,
   };
 }
 
@@ -57,6 +62,45 @@ function runBots(roomId) {
     }, 500 * (idx + 1));
   });
 }
+
+function createGameState(room) {
+  const ship = { temperature: 100, oxygen: 100, hull: 100, morale: 100 };
+  const roles = ['Engineer', 'Psychologist', 'Navigator', 'Operator'];
+  const objectives = [
+    'Keep morale above 90',
+    'Change the captain once',
+    'Keep hull above 50',
+    'Reduce oxygen below 30',
+  ];
+  const players = {};
+  const ids = Object.keys(room.players);
+  ids.forEach((id, idx) => {
+    const role = roles[idx % roles.length];
+    const objective = objectives[idx % objectives.length];
+    room.players[id].role = role;
+    players[id] = {
+      role,
+      objective,
+      abilityCharge: 0,
+      cooldown: 0,
+      chosenCard: null,
+    };
+  });
+  return { ship, players };
+}
+
+const CARD_EFFECTS = [
+  { hull: -5 },
+  { oxygen: -5 },
+  { morale: 5 },
+];
+
+const ABILITY_EFFECTS = {
+  Engineer: { hull: 20 },
+  Psychologist: { morale: 20 },
+  Navigator: { oxygen: 20 },
+  Operator: { temperature: -10 },
+};
 
 io.on('connection', (socket) => {
   socket.on('createRoom', (callback) => {
@@ -92,20 +136,56 @@ io.on('connection', (socket) => {
     const room = rooms[roomId];
     if (!room) return;
     room.gameStarted = true;
+    room.round = 1;
+    room.game = createGameState(room);
     io.to(roomId).emit('gameStarted', getState(roomId));
+    io.to(roomId).emit('stateUpdate', getState(roomId));
     if (OFFLINE) runBots(roomId);
   });
 
   socket.on('playCard', ({ roomId, cardIndex }) => {
+    const room = rooms[roomId];
+    if (!room || !room.game) return;
+    if (room.game.players[socket.id]) {
+      room.game.players[socket.id].chosenCard = cardIndex;
+    }
     io.to(roomId).emit('cardPlayed', { playerId: socket.id, cardIndex });
+    io.to(roomId).emit('stateUpdate', getState(roomId));
   });
 
   socket.on('captainSelect', ({ roomId, selectedPlayerId }) => {
+    const room = rooms[roomId];
+    if (!room || !room.game) return;
+    const player = room.game.players[selectedPlayerId];
+    if (!player) return;
+    const cardIdx = player.chosenCard;
+    const effect = CARD_EFFECTS[cardIdx] || {};
+    Object.entries(effect).forEach(([k, v]) => {
+      if (room.game.ship[k] !== undefined) {
+        room.game.ship[k] = Math.max(0, Math.min(100, room.game.ship[k] + v));
+      }
+    });
+    player.chosenCard = null;
+    player.abilityCharge = Math.min(100, player.abilityCharge + 20);
     io.to(roomId).emit('stateUpdate', getState(roomId));
   });
 
   socket.on('useAbility', ({ roomId }) => {
+    const room = rooms[roomId];
+    if (!room) return;
+    const player = room.game && room.game.players[socket.id];
+    if (player && player.abilityCharge >= 100 && player.cooldown === 0) {
+      const effect = ABILITY_EFFECTS[player.role] || {};
+      Object.entries(effect).forEach(([k, v]) => {
+        if (room.game.ship[k] !== undefined) {
+          room.game.ship[k] = Math.max(0, Math.min(100, room.game.ship[k] + v));
+        }
+      });
+      player.abilityCharge = 0;
+      player.cooldown = 4;
+    }
     io.to(roomId).emit('abilityUsed', { playerId: socket.id, state: getState(roomId) });
+    io.to(roomId).emit('stateUpdate', getState(roomId));
   });
 
   socket.on('proposeCoup', ({ roomId, anonymous }) => {
@@ -134,9 +214,20 @@ io.on('connection', (socket) => {
 
   socket.on('nextRound', ({ roomId }) => {
     const room = rooms[roomId];
-    if (!room) return;
+    if (!room || !room.game) return;
     room.round += 1;
-    io.to(roomId).emit('newRound', { event: 'event', state: getState(roomId) });
+    const keys = Object.keys(room.game.ship);
+    const key = keys[Math.floor(Math.random() * keys.length)];
+    room.game.ship[key] = Math.max(0, room.game.ship[key] - 5);
+    Object.values(room.game.players).forEach(p => {
+      if (p.cooldown > 0) {
+        p.cooldown -= 1;
+      } else {
+        p.abilityCharge = Math.min(100, p.abilityCharge + 20);
+      }
+    });
+    io.to(roomId).emit('newRound', { event: key, state: getState(roomId) });
+    io.to(roomId).emit('stateUpdate', getState(roomId));
     if (OFFLINE) runBots(roomId);
   });
 


### PR DESCRIPTION
## Summary
- implement `createGameState` helper
- add card and ability effect handling
- track ability cooldown and ship parameters
- send updated game state after actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fdd72a95c83329bc12509f80dca32