### PR TITLE
Update client UI to display game state

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -3,14 +3,73 @@ const login = document.getElementById('login');
 const game = document.getElementById('game');
 const statusEl = document.getElementById('status');
 const chat = document.getElementById('chat');
+const roundEl = document.getElementById('round');
+const shipEls = {
+  temperature: document.getElementById('ship-temperature'),
+  oxygen: document.getElementById('ship-oxygen'),
+  hull: document.getElementById('ship-hull'),
+  morale: document.getElementById('ship-morale'),
+};
+const playersEl = document.getElementById('players');
+const cardsEl = document.getElementById('cards');
+const abilityBtn = document.getElementById('ability');
+const coupBtn = document.getElementById('coup');
+const voteDiv = document.getElementById('vote');
+const voteYesBtn = document.getElementById('voteYes');
+const voteNoBtn = document.getElementById('voteNo');
 
 let roomId = null;
+let currentState = null;
 
 function addMsg(msg) {
   const p = document.createElement('p');
   p.textContent = msg;
   chat.appendChild(p);
   chat.scrollTop = chat.scrollHeight;
+}
+
+function renderState(state) {
+  currentState = state;
+  if (!state) return;
+
+  roundEl.textContent = 'Round: ' + (state.round || 0);
+
+  if (state.game && state.game.ship) {
+    for (const [k, v] of Object.entries(state.game.ship)) {
+      if (shipEls[k]) shipEls[k].textContent = v;
+    }
+  }
+
+  playersEl.innerHTML = '';
+  if (state.players) {
+    state.players.forEach(p => {
+      const div = document.createElement('div');
+      let role = p.id === socket.id ? p.role : '???';
+      if (state.captain === p.id) role += ' (Captain)';
+      div.textContent = p.name + ' - ' + role;
+      playersEl.appendChild(div);
+    });
+  }
+
+  const myData = state.game && state.game.players && state.game.players[socket.id];
+  if (myData) {
+    abilityBtn.disabled = !(myData.abilityCharge >= 100 && myData.cooldown === 0);
+    abilityBtn.textContent = 'Use Ability (' + myData.abilityCharge + '%)';
+
+    cardsEl.innerHTML = '';
+    if (myData.chosenCard === null) {
+      for (let i = 0; i < 3; i++) {
+        const btn = document.createElement('button');
+        btn.textContent = 'Card ' + (i + 1);
+        btn.onclick = () => {
+          socket.emit('playCard', { roomId, cardIndex: i });
+        };
+        cardsEl.appendChild(btn);
+      }
+    } else {
+      cardsEl.textContent = 'Played card ' + (myData.chosenCard + 1);
+    }
+  }
 }
 
 document.getElementById('create').onclick = () => {
@@ -44,12 +103,26 @@ document.getElementById('start').onclick = () => {
   socket.emit('startGame', { roomId });
 };
 
-document.getElementById('play').onclick = () => {
-  socket.emit('playCard', { roomId, cardIndex: 0 });
-};
-
 document.getElementById('next').onclick = () => {
   socket.emit('nextRound', { roomId });
+};
+
+abilityBtn.onclick = () => {
+  socket.emit('useAbility', { roomId });
+};
+
+coupBtn.onclick = () => {
+  socket.emit('proposeCoup', { roomId, anonymous: false });
+};
+
+voteYesBtn.onclick = () => {
+  socket.emit('voteCoup', { roomId, vote: true });
+  voteDiv.style.display = 'none';
+};
+
+voteNoBtn.onclick = () => {
+  socket.emit('voteCoup', { roomId, vote: false });
+  voteDiv.style.display = 'none';
 };
 
 document.getElementById('send').onclick = () => {
@@ -64,16 +137,37 @@ socket.on('chatMessage', (msg) => {
 
 socket.on('gameStarted', (state) => {
   addMsg('Game started');
+  renderState(state);
 });
 
 socket.on('cardPlayed', ({ playerId, cardIndex }) => {
-  addMsg(playerId + ' played card ' + cardIndex);
+  addMsg(playerId + ' played card ' + (cardIndex + 1));
 });
 
 socket.on('newRound', ({ event, state }) => {
   addMsg('New round ' + state.round);
+  renderState(state);
 });
 
-socket.on('abilityUsed', ({ playerId }) => {
+socket.on('abilityUsed', ({ playerId, state }) => {
   addMsg(playerId + ' used their ability');
+  if (state) renderState(state);
+});
+
+socket.on('stateUpdate', (state) => {
+  renderState(state);
+});
+
+socket.on('voteStarted', ({ initiator }) => {
+  addMsg('Vote started');
+  voteDiv.style.display = 'block';
+});
+
+socket.on('coupResult', ({ result, captain }) => {
+  addMsg('Coup ' + (result ? 'succeeded' : 'failed'));
+  voteDiv.style.display = 'none';
+  if (currentState) {
+    currentState.captain = captain;
+    renderState(currentState);
+  }
 });

--- a/client/index.html
+++ b/client/index.html
@@ -20,8 +20,22 @@
 
   <div id="game" style="display:none;">
     <p id="status"></p>
+    <div id="round"></div>
+    <div id="ship">
+      <div>Temperature: <span id="ship-temperature"></span></div>
+      <div>Oxygen: <span id="ship-oxygen"></span></div>
+      <div>Hull: <span id="ship-hull"></span></div>
+      <div>Morale: <span id="ship-morale"></span></div>
+    </div>
+    <div id="players"></div>
+    <div id="cards"></div>
+    <button id="ability">Use Ability</button>
+    <button id="coup">Start Coup</button>
+    <div id="vote" style="display:none;">
+      <button id="voteYes">Vote Yes</button>
+      <button id="voteNo">Vote No</button>
+    </div>
     <button id="start">Start Game</button>
-    <button id="play">Play Card</button>
     <button id="next">Next Round</button>
     <div id="chat"></div>
     <input id="text" placeholder="Say something" />


### PR DESCRIPTION
## Summary
- add interface panels for ship parameters, round, player list, available cards, ability and coup buttons
- render these panels from server state updates in `client.js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fe3e768588332badd2d8b0985b7a8