### PR TITLE
Implement cards and events

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -29,6 +29,8 @@
     </div>
     <div id="players"></div>
     <div id="cards"></div>
+    <div id="offered"></div>
+    <div id="timer"></div>
     <button id="ability">Use Ability</button>
     <button id="coup">Start Coup</button>
     <div id="vote" style="display:none;">

--- a/server/cards.js
+++ b/server/cards.js
@@ -1,0 +1,24 @@
+const decks = {
+  Engineer: [
+    { name: 'Repair Hull', description: 'Patch small breaches in the hull.', effect: { hull: 10 } },
+    { name: 'Vent Plasma', description: 'Lower temperature by venting plasma.', effect: { temperature: -5 } },
+    { name: 'Reinforce Bulkhead', description: 'Improve hull integrity slightly.', effect: { hull: 5 } },
+  ],
+  Psychologist: [
+    { name: 'Motivational Speech', description: 'Raise crew morale.', effect: { morale: 10 } },
+    { name: 'Calming Therapy', description: 'Reduce stress for a small morale gain.', effect: { morale: 5 } },
+    { name: 'Harsh Critique', description: 'Morale drops a bit but reveals issues.', effect: { morale: -5 } },
+  ],
+  Navigator: [
+    { name: 'Plot Safe Course', description: 'Avoid dangerous sectors.', effect: { temperature: -5 } },
+    { name: 'Short Warp', description: 'Consume oxygen to jump forward.', effect: { oxygen: -5 } },
+    { name: 'Sensor Sweep', description: 'Scan ahead for threats.', effect: { hull: 0 } },
+  ],
+  Operator: [
+    { name: 'Scan Frequencies', description: 'Boost morale slightly.', effect: { morale: 5 } },
+    { name: 'Override Alarms', description: 'Cool the ship but strain the hull.', effect: { temperature: -5, hull: -5 } },
+    { name: 'Open Channels', description: 'Communication boost at oxygen cost.', effect: { oxygen: -5, morale: 5 } },
+  ],
+};
+
+module.exports = { decks };

--- a/server/events.js
+++ b/server/events.js
@@ -1,0 +1,12 @@
+const events = [
+  { name: 'Meteor Shower', effect: { hull: -10 } },
+  { name: 'Oxygen Leak', effect: { oxygen: -10 } },
+  { name: 'Crew Panic', effect: { morale: -10 } },
+  { name: 'Cooling Failure', effect: { temperature: 10 } },
+];
+
+function randomEvent() {
+  return events[Math.floor(Math.random() * events.length)];
+}
+
+module.exports = { events, randomEvent };

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -68,8 +68,8 @@ describe('Server basic flow', function () {
         expect(state.roomId).to.equal(roomId);
         socket.emit('playCard', { roomId, cardIndex: 0 });
       });
-      socket.on('cardPlayed', ({ cardIndex }) => {
-        expect(cardIndex).to.equal(0);
+      socket.on('cardPlayed', ({ playerId }) => {
+        expect(playerId).to.be.a('string');
         socket2.close();
         done();
       });


### PR DESCRIPTION
## Summary
- create deck lists for each profession
- add random event module
- generate cards for each round
- send hidden cards to captain and handle selection
- show card names with a timer on the client
- adjust tests for new behavior

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe70613608332b22df22f1f4c7fa4