### PR TITLE
Add personal objectives and saboteurs

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -31,6 +31,7 @@
     <div id="cards"></div>
     <div id="offered"></div>
     <div id="timer"></div>
+    <div id="objective" style="margin-top:10px;"></div>
     <button id="ability">Use Ability</button>
     <button id="coup">Start Coup</button>
     <div id="vote" style="display:none;">
@@ -38,6 +39,7 @@
       <button id="voteNo">Vote No</button>
     </div>
     <button id="start">Start Game</button>
+    <button id="end">End Game</button>
     <button id="next">Next Round</button>
     <div id="chat"></div>
     <input id="text" placeholder="Say something" />


### PR DESCRIPTION
## Summary
- choose 1-2 saboteurs when the game starts
- keep a personal objective for each player
- send each player their goal via new `personalObjective` event
- hide goals from shared state
- allow players to end the game to reveal roles and goal success
- show personal goal on the client

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fe8b487488332be2623d5021d9fd0