### PR TITLE
Notify captain of private chats

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -203,6 +203,10 @@ socket.on('chatMessage', (msg) => {
   addMsg((msg.private ? '(private) ' : '') + msg.from + ': ' + msg.text);
 });
 
+socket.on('chatNotice', () => {
+  addMsg('(notice) Private message exchanged');
+});
+
 socket.on('gameStarted', (state) => {
   addMsg('Game started');
   renderState(state);

--- a/server/index.js
+++ b/server/index.js
@@ -357,8 +357,13 @@ io.on('connection', (socket) => {
   });
 
   socket.on('chatPrivate', ({ roomId, to, text }) => {
+    const room = rooms[roomId];
+    if (!room) return;
     io.to(to).emit('chatMessage', { from: socket.id, text, private: true });
     socket.emit('chatMessage', { from: socket.id, text, to, private: true });
+    if (room.captain) {
+      io.to(room.captain).emit('chatNotice', { from: socket.id, to });
+    }
   });
 
   socket.on('endGame', ({ roomId }) => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -109,6 +109,25 @@ describe('Server basic flow', function () {
     });
   });
 
+  it('notifies the captain on private messages', (done) => {
+    socket.emit('createRoom', ({ roomId }) => {
+      const socket2 = io(`http://localhost:${SERVER_PORT}`);
+      const socket3 = io(`http://localhost:${SERVER_PORT}`);
+      socket2.emit('joinRoom', { roomId, name: 'Bob' }, () => {
+        socket3.emit('joinRoom', { roomId, name: 'Carol' }, () => {
+          socket.once('chatNotice', ({ from, to }) => {
+            expect(from).to.equal(socket2.id);
+            expect(to).to.equal(socket3.id);
+            socket2.close();
+            socket3.close();
+            done();
+          });
+          socket2.emit('chatPrivate', { roomId, to: socket3.id, text: 'hi' });
+        });
+      });
+    });
+  });
+
   it('changes captain to coup initiator when vote passes', (done) => {
     socket.emit('createRoom', ({ roomId }) => {
       const socket2 = io(`http://localhost:${SERVER_PORT}`);


### PR DESCRIPTION
## Summary
- emit a `chatNotice` to the captain when players exchange a private chat
- display a small notice in the client on `chatNotice`
- test that the captain receives the notice for private chats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860333955e88332afda17344020cf4e